### PR TITLE
Bug 61 default fhir loading

### DIFF
--- a/redmatch-grammar/src/main/java/au/csiro/redmatch/terminology/TerminologyService.java
+++ b/redmatch-grammar/src/main/java/au/csiro/redmatch/terminology/TerminologyService.java
@@ -39,6 +39,8 @@ public class TerminologyService {
   private static final String REDMATCH_PREFIX = "http://redmatch.";
 
   private final InternalApi onto;
+  private FhirContext ctx;
+  private Gson gson;
 
   /**
    * Used to make sure the system does not attempt to index validation code system simultaneously.
@@ -47,6 +49,47 @@ public class TerminologyService {
     new LinkedBlockingDeque<>(10);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+
+  public boolean ontoIndexCheck(VersionedFhirPackage fhirPackage) {
+    return onto.isIndexed(REDMATCH_PREFIX + fhirPackage.getName(), fhirPackage.getVersion());
+  }
+  public void checkPackage(VersionedFhirPackage fhirPackage, ProgressReporter progressReporter) {
+    log.debug("Checking if FHIR package " + fhirPackage + " is installed");
+    try {
+      Instant start = Instant.now();
+      log.debug("Package is not indexed");
+      RedmatchGrammarCodeSystemGenerator generator = new RedmatchGrammarCodeSystemGenerator(gson, ctx);
+      CodeSystem cs = generator.createCodeSystem(fhirPackage, progressReporter);
+
+      if (progressReporter != null) {
+        progressReporter.reportProgress(Progress.reportStart("Indexing code system for FHIR package "
+          + fhirPackage));
+      }
+      Path targetFolder = onto.indexFhirCodeSystem(cs);
+      if (progressReporter != null) {
+        progressReporter.reportProgress(Progress.reportEnd());
+      }
+  
+      Path targetFile = targetFolder.resolve(fhirPackage.getName() + ".json");
+      try (FileWriter fw = new FileWriter(targetFile.toFile())) {
+        if (progressReporter != null) {
+          progressReporter.reportProgress(Progress.reportStart("Saving generated code system for FHIR package "
+            + fhirPackage));
+        }
+        ctx.newJsonParser().setPrettyPrint(true).encodeResourceToWriter(cs, fw);
+        if (progressReporter != null) {
+          progressReporter.reportProgress(Progress.reportEnd());
+        }
+      }
+      Instant finish = Instant.now();
+      long timeElapsed = Duration.between(start, finish).toMillis();
+      log.info("Finished checking in: " + DateUtils.prettyPrintMillis(timeElapsed));
+    } catch (IOException e) {
+      log.error("There was an IO error processing FHIR package " + fhirPackage, e);
+      Thread.currentThread().interrupt();
+    }
+  }
 
   /**
    * Constructor.
@@ -57,6 +100,8 @@ public class TerminologyService {
   public TerminologyService(FhirContext ctx, Gson gson) {
     log.info("Initialising terminology service");
     onto = new InternalApi(gson, ctx);
+    this.ctx = ctx;
+    this.gson = gson;
 
     Runnable indexingTask = () -> {
       try {
@@ -64,41 +109,8 @@ public class TerminologyService {
           Triplet<VersionedFhirPackage, CompletableFuture<Void>, ProgressReporter> item = blockingQueue.take();
           VersionedFhirPackage fhirPackage = item.getValue0();
           ProgressReporter progressReporter = item.getValue2();
-          log.debug("Checking if FHIR package " + fhirPackage + " is installed");
-          try {
-            Instant start = Instant.now();
-            log.debug("Package is not indexed");
-            RedmatchGrammarCodeSystemGenerator generator = new RedmatchGrammarCodeSystemGenerator(gson, ctx);
-            CodeSystem cs = generator.createCodeSystem(fhirPackage, progressReporter);
-
-            if (progressReporter != null) {
-              progressReporter.reportProgress(Progress.reportStart("Indexing code system for FHIR package "
-                + fhirPackage));
-            }
-            Path targetFolder = onto.indexFhirCodeSystem(cs);
-            if (progressReporter != null) {
-              progressReporter.reportProgress(Progress.reportEnd());
-            }
-
-            Path targetFile = targetFolder.resolve(fhirPackage.getName() + ".json");
-            try (FileWriter fw = new FileWriter(targetFile.toFile())) {
-              if (progressReporter != null) {
-                progressReporter.reportProgress(Progress.reportStart("Saving generated code system for FHIR package "
-                  + fhirPackage));
-              }
-              ctx.newJsonParser().setPrettyPrint(true).encodeResourceToWriter(cs, fw);
-              if (progressReporter != null) {
-                progressReporter.reportProgress(Progress.reportEnd());
-              }
-            }
-            Instant finish = Instant.now();
-            long timeElapsed = Duration.between(start, finish).toMillis();
-            log.info("Finished checking in: " + DateUtils.prettyPrintMillis(timeElapsed));
-            item.getValue1().complete(null);
-          } catch (IOException e) {
-            log.error("There was an IO error processing FHIR package " + item.getValue0(), e);
-            Thread.currentThread().interrupt();
-          }
+          checkPackage(fhirPackage, progressReporter);
+          item.getValue1().complete(null);
         }
       } catch (InterruptedException e) {
         log.error("Thread was interrupted.", e);
@@ -137,7 +149,7 @@ public class TerminologyService {
 
     CompletableFuture<Void> future = new CompletableFuture<>();
 
-    if (onto.isIndexed(REDMATCH_PREFIX + fhirPackage.getName(), fhirPackage.getVersion())) {
+    if (ontoIndexCheck(fhirPackage)) {
       if (progressReporter != null) {
         progressReporter.reportProgress(Progress.reportStart("Adding package " + fhirPackage));
       }

--- a/redmatch-language-server/src/main/java/au/csiro/redmatch/lsp/RedmatchLanguageServer.java
+++ b/redmatch-language-server/src/main/java/au/csiro/redmatch/lsp/RedmatchLanguageServer.java
@@ -35,7 +35,6 @@ public class RedmatchLanguageServer implements LanguageServer, LanguageClientAwa
   private LanguageClient client;
   private final RedmatchApi api;
   private final VersionedFhirPackage defaultFhirPackage;
-  private final ProgressReporter progressReporter;
 
   /**
    * Constructor.
@@ -46,18 +45,9 @@ public class RedmatchLanguageServer implements LanguageServer, LanguageClientAwa
     // TODO: would be good to allow users to set the default FHIR package through configuration options
     defaultFhirPackage = new VersionedFhirPackage("hl7.fhir.r4.core", "4.0.1");
     TerminologyService terminologyService = new TerminologyService(ctx, gson);
-    progressReporter = new LspProgressReporter(this);
+    ProgressReporter progressReporter = new LspProgressReporter(this);
     RedmatchCompiler compiler = new RedmatchCompiler(gson, terminologyService, defaultFhirPackage, progressReporter);
-    if (!terminologyService.ontoIndexCheck(defaultFhirPackage)) {
-      log.info("defaultFhirPackage not detected by index on initialisation");
-      try {
-        terminologyService.checkPackage(defaultFhirPackage, null);
-      } catch (IOException e) {
-        throw new RuntimeException("Tried and failed to load the Default FHIR package.", e);
-      }
-    }
-    HapiReflectionHelper reflectionHelper = new HapiReflectionHelper(ctx, defaultFhirPackage, terminologyService);
-    api = new RedmatchApi(ctx, gson, compiler, reflectionHelper, terminologyService);
+    api = new RedmatchApi(ctx, gson, compiler, defaultFhirPackage, terminologyService, progressReporter);
     textDocumentService = new RedmatchTextDocumentService(this, terminologyService);
     workspaceService = new RedmatchWorkspaceService(this);
   }

--- a/redmatch-language-server/src/main/java/au/csiro/redmatch/lsp/RedmatchLanguageServer.java
+++ b/redmatch-language-server/src/main/java/au/csiro/redmatch/lsp/RedmatchLanguageServer.java
@@ -19,6 +19,7 @@ import org.eclipse.lsp4j.services.*;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.io.IOException;
 
 /**
  * The Redmatch language server implementation.
@@ -49,7 +50,11 @@ public class RedmatchLanguageServer implements LanguageServer, LanguageClientAwa
     RedmatchCompiler compiler = new RedmatchCompiler(gson, terminologyService, defaultFhirPackage, progressReporter);
     if (!terminologyService.ontoIndexCheck(defaultFhirPackage)) {
       log.info("defaultFhirPackage not detected by index on initialisation");
-      terminologyService.checkPackage(defaultFhirPackage, null);
+      try {
+        terminologyService.checkPackage(defaultFhirPackage, null);
+      } catch (IOException e) {
+        throw new RuntimeException("Tried and failed to load the Default FHIR package.", e);
+      }
     }
     HapiReflectionHelper reflectionHelper = new HapiReflectionHelper(ctx, defaultFhirPackage, terminologyService);
     api = new RedmatchApi(ctx, gson, compiler, reflectionHelper, terminologyService);


### PR DESCRIPTION
The change forces the defaultFhirPackage to be checked (and if absent, consequently loaded) prior to the initialisation of the HapiReflectionHelper (which then immediately attempts to load the defaultFhirPackage files - and would otherwise fail).
it will hard fail if it needs and cannot download thoes initial files (so perhaps we should add a proper warning message for the user or something, at some point) but should still be quite an improvement.

Resolves #61.